### PR TITLE
Add minimal ZK ticketing prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# BDAG-ZKP
+# ZK-Tix: Private, Scalable BDAG Ticketing Platform
+
+This repository contains a minimal prototype for a zero‑knowledge based event ticketing system built for the BlockDAG network.
+
+## Components
+
+- `frontend/index.html` – basic web page to connect a wallet, buy tickets and transfer them using proofs.
+- `frontend/ticketing.js` – interacts with the deployed smart contract and includes placeholders for ZKP generation.
+- `contracts/Ticketing.sol` – Solidity contract implementing ticket minting and transfer with proof verification.
+- `circuits/zkp_circuit.circom` – Circom circuit sketch enforcing simple human and anti‑resale rules.
+
+The project is intentionally lightweight and focuses on demonstrating how ZK proofs could restrict ticket transfers without revealing user identities.

--- a/circuits/zkp_circuit.circom
+++ b/circuits/zkp_circuit.circom
@@ -1,0 +1,25 @@
+pragma circom 2.0.0;
+
+include "circomlib/circuits/sha256/sha256.circom";
+
+template TicketEligibility() {
+    signal input ticketId;
+    signal input senderHash;
+    signal input recipientHash;
+    signal input captchaHash;
+    signal input ticketCount; // number of tickets sender owns
+
+    // Ensure captcha is solved (dummy check for equality to 1)
+    signal input captchaSolved; // 1 if solved
+    captchaSolved === 1;
+
+    // Check ticketCount < 2
+    component isLessThan = LessThan(32);
+    isLessThan.in[0] <== ticketCount;
+    isLessThan.in[1] <== 2;
+    isLessThan.out === 1;
+
+    // Nothing else enforced in this simplified circuit
+}
+
+component main = TicketEligibility();

--- a/contracts/Ticketing.sol
+++ b/contracts/Ticketing.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IZKPVerifier {
+    function verifyProof(bytes calldata proof, uint256[3] calldata publicSignals) external view returns (bool);
+}
+
+contract Ticketing is ERC721, Ownable {
+    struct EventInfo {
+        string name;
+        uint256 price;
+        uint256 remaining;
+    }
+
+    IERC20 public immutable bdag;
+    IZKPVerifier public verifier;
+    uint256 public nextEventId;
+    uint256 public nextTicketId;
+
+    mapping(uint256 => EventInfo) public events;
+    mapping(uint256 => uint256) public ticketEvent;
+
+    constructor(address bdagToken, address proofVerifier) ERC721("ZK-Tix", "ZKTIX") {
+        bdag = IERC20(bdagToken);
+        verifier = IZKPVerifier(proofVerifier);
+    }
+
+    function createEvent(string calldata name, uint256 price, uint256 tickets) external onlyOwner {
+        events[nextEventId] = EventInfo(name, price, tickets);
+        nextEventId++;
+    }
+
+    function getEvents() external view returns (EventInfo[] memory evs) {
+        evs = new EventInfo[](nextEventId);
+        for (uint256 i = 0; i < nextEventId; i++) {
+            evs[i] = events[i];
+        }
+    }
+
+    function buyTicket(uint256 eventId) external {
+        EventInfo storage ev = events[eventId];
+        require(ev.remaining > 0, "Sold out");
+        ev.remaining -= 1;
+        require(bdag.transferFrom(msg.sender, owner(), ev.price), "Payment failed");
+        _mint(msg.sender, nextTicketId);
+        ticketEvent[nextTicketId] = eventId;
+        nextTicketId++;
+    }
+
+    function transferWithProof(uint256 ticketId, address to, bytes calldata proof) external {
+        require(ownerOf(ticketId) == msg.sender, "Not owner");
+        uint256[3] memory pubSignals = [uint256(ticketId), uint256(uint160(msg.sender)), uint256(uint160(to))];
+        require(verifier.verifyProof(proof, pubSignals), "Invalid proof");
+        _transfer(msg.sender, to, ticketId);
+    }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ZK-Tix</title>
+    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.min.js" integrity="sha256-DGgUMkE8hELiTAAxV8jTwjWF4DwFNhe4okW8uP5cHYc=" crossorigin="anonymous"></script>
+    <script src="ticketing.js"></script>
+</head>
+<body>
+    <button onclick="connectWallet()">Connect Wallet</button>
+
+    <div id="events"></div>
+
+    <div id="buySection" style="display:none;">
+        <button id="buyBtn">Buy Ticket</button>
+    </div>
+
+    <h3>Transfer Ticket</h3>
+    <input type="text" id="recipient" placeholder="Recipient Wallet Address" />
+    <button id="transferBtn">Transfer Ticket</button>
+
+    <script>
+        window.addEventListener('load', function() {
+            init();
+        });
+    </script>
+</body>
+</html>

--- a/frontend/ticketing.js
+++ b/frontend/ticketing.js
@@ -1,0 +1,70 @@
+let provider;
+let signer;
+let contract;
+
+const contractAddress = "0xYourContractAddress"; // replace with deployed address
+const abi = [
+    "function buyTicket(uint256 eventId) public",
+    "function transferWithProof(uint256 ticketId, address to, bytes calldata proof) public",
+    "function getEvents() public view returns(tuple(uint256 id,string name,uint256 price,uint256 remaining)[])"
+];
+
+async function init() {
+    const buyBtn = document.getElementById('buyBtn');
+    const transferBtn = document.getElementById('transferBtn');
+    buyBtn.addEventListener('click', () => buyTicket(0));
+    transferBtn.addEventListener('click', () => generateProofAndTransfer(0));
+}
+
+async function connectWallet() {
+    if (!window.ethereum) {
+        alert('MetaMask not detected');
+        return;
+    }
+    await window.ethereum.request({ method: 'eth_requestAccounts' });
+    provider = new ethers.providers.Web3Provider(window.ethereum);
+    signer = provider.getSigner();
+    contract = new ethers.Contract(contractAddress, abi, signer);
+    loadEvents();
+}
+
+async function loadEvents() {
+    const events = await contract.getEvents();
+    const container = document.getElementById('events');
+    container.innerHTML = '';
+    events.forEach(ev => {
+        const div = document.createElement('div');
+        div.innerHTML = `${ev.id}: ${ev.name} - Price: ${ev.price}`;
+        container.appendChild(div);
+    });
+    document.getElementById('buySection').style.display = 'block';
+}
+
+async function buyTicket(eventId) {
+    try {
+        const tx = await contract.buyTicket(eventId);
+        await tx.wait();
+        alert('Ticket purchased!');
+    } catch (err) {
+        console.error(err);
+        alert('Purchase failed');
+    }
+}
+
+async function generateProofAndTransfer(ticketId) {
+    const recipient = document.getElementById('recipient').value;
+    if (!recipient) {
+        alert('Enter recipient');
+        return;
+    }
+    // TODO: integrate real ZKP generation with SnarkJS
+    const proof = '0x00'; // placeholder
+    try {
+        const tx = await contract.transferWithProof(ticketId, recipient, proof);
+        await tx.wait();
+        alert('Transfer complete');
+    } catch (err) {
+        console.error(err);
+        alert('Transfer failed');
+    }
+}


### PR DESCRIPTION
## Summary
- create simple frontend to connect wallet and buy/transfer tickets
- add JS logic for contract calls and placeholder ZKP generation
- implement `Ticketing` contract with proof‐gated transfers
- sketch Circom circuit enforcing captcha and ticket limits
- document repository purpose

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886030a21a08323b978e9d775ac63e8