### PR TITLE
Add ticket price range enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ This repository contains a minimal prototype for a zero‑knowledge based event 
 - `contracts/Ticketing.sol` – Solidity contract implementing ticket minting and transfer with proof verification.
 - `circuits/zkp_circuit.circom` – Circom circuit sketch enforcing simple human and anti‑resale rules.
 
+Event prices are restricted on-chain to between **10** and **50** BDAG tokens to keep ticket costs reasonable.
+
 The project is intentionally lightweight and focuses on demonstrating how ZK proofs could restrict ticket transfers without revealing user identities.

--- a/contracts/Ticketing.sol
+++ b/contracts/Ticketing.sol
@@ -10,6 +10,8 @@ interface IZKPVerifier {
 }
 
 contract Ticketing is ERC721, Ownable {
+    uint256 public constant MIN_PRICE = 10 ether;
+    uint256 public constant MAX_PRICE = 50 ether;
     struct EventInfo {
         string name;
         uint256 price;
@@ -30,6 +32,7 @@ contract Ticketing is ERC721, Ownable {
     }
 
     function createEvent(string calldata name, uint256 price, uint256 tickets) external onlyOwner {
+        require(price >= MIN_PRICE && price <= MAX_PRICE, "Price out of range");
         events[nextEventId] = EventInfo(name, price, tickets);
         nextEventId++;
     }
@@ -44,6 +47,7 @@ contract Ticketing is ERC721, Ownable {
     function buyTicket(uint256 eventId) external {
         EventInfo storage ev = events[eventId];
         require(ev.remaining > 0, "Sold out");
+        require(ev.price >= MIN_PRICE && ev.price <= MAX_PRICE, "Invalid ticket price");
         ev.remaining -= 1;
         require(bdag.transferFrom(msg.sender, owner(), ev.price), "Payment failed");
         _mint(msg.sender, nextTicketId);


### PR DESCRIPTION
## Summary
- restrict event pricing between 10 and 50 BDAG tokens
- validate ticket price during purchase
- document price limits in README

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68860b04b8b88323bf727150dbf3365c