### PR TITLE
Implement multiple ticket purchase options

### DIFF
--- a/contracts/Ticketing.sol
+++ b/contracts/Ticketing.sol
@@ -29,6 +29,12 @@ contract Ticketing is ERC721, Ownable {
     constructor(address bdagToken, address proofVerifier) ERC721("ZK-Tix", "ZKTIX") {
         bdag = IERC20(bdagToken);
         verifier = IZKPVerifier(proofVerifier);
+
+        // pre-create three ticket types
+        events[0] = EventInfo("Option 1", 10 ether, 1000);
+        events[1] = EventInfo("Option 2", 25 ether, 1000);
+        events[2] = EventInfo("Option 3", 50 ether, 1000);
+        nextEventId = 3;
     }
 
     function createEvent(string calldata name, uint256 price, uint256 tickets) external onlyOwner {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,7 @@
         <div id="events"></div>
 
         <div id="buySection">
+            <select id="ticketSelect"></select>
             <button id="buyBtn">Buy Ticket</button>
         </div>
 

--- a/frontend/ticketing.js
+++ b/frontend/ticketing.js
@@ -12,7 +12,11 @@ const abi = [
 async function init() {
     const buyBtn = document.getElementById('buyBtn');
     const transferBtn = document.getElementById('transferBtn');
-    buyBtn.addEventListener('click', () => buyTicket(0));
+    buyBtn.addEventListener('click', () => {
+        const select = document.getElementById('ticketSelect');
+        const eventId = parseInt(select.value, 10);
+        buyTicket(eventId);
+    });
     transferBtn.addEventListener('click', () => generateProofAndTransfer(0));
 }
 
@@ -32,10 +36,17 @@ async function loadEvents() {
     const events = await contract.getEvents();
     const container = document.getElementById('events');
     container.innerHTML = '';
+    const select = document.getElementById('ticketSelect');
+    select.innerHTML = '';
     events.forEach(ev => {
         const div = document.createElement('div');
         div.innerHTML = `${ev.id}: ${ev.name} - Price: ${ev.price}`;
         container.appendChild(div);
+
+        const opt = document.createElement('option');
+        opt.value = ev.id;
+        opt.textContent = `${ev.name} - ${ethers.utils.formatUnits(ev.price, 18)} BDAG`;
+        select.appendChild(opt);
     });
     document.getElementById('buySection').style.display = 'block';
 }


### PR DESCRIPTION
## Summary
- add dropdown for ticket choices
- wire frontend purchase button to selected option
- populate dropdown when events load
- pre-create three ticket types in the smart contract

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68860c5427fc8323b06b378bd9cf1cdf